### PR TITLE
当出现 flood 时候还是返回数据并增加 redis key 过期时间参数

### DIFF
--- a/src/clj_rate_limiter/core.clj
+++ b/src/clj_rate_limiter/core.clj
@@ -170,8 +170,8 @@
         (allow? [this id]
           (:result (permit? this id)))
         (permit? [_ id]
-          (when-not (and flood-threshold
-                         (cache/lookup @flood-cache (or id "")))
+          (if-not (and flood-threshold
+                       (cache/lookup @flood-cache (or id "")))
             (let [id (or id "")
                   stamp (System/nanoTime)
                   now (System/currentTimeMillis)
@@ -203,11 +203,9 @@
                                                    too-many-in-interval?
                                                    time-since-last-req
                                                    min-difference interval))]
-                  (if ret
-                    {:result ret :ts stamp
-                     :current total :total (+ total rs-total)}
-                    {:result ret :ts stamp
-                     :current total :total (+ total rs-total)}))))))
+                  {:result ret :ts stamp :current total :total (+ total rs-total)})))
+            (let [flood-total (* flood-threshold max-in-interval)]
+              {:result false :flood-request? true :current flood-total :total flood-total})))
         (remove-permit [_ id ts]
           (let [id (or id "")
                 key (format "%s-%s" namespace id)

--- a/src/clj_rate_limiter/core.clj
+++ b/src/clj_rate_limiter/core.clj
@@ -161,11 +161,11 @@
   RateLimiterFactory
   (create [this]
     (let [{:keys [interval min-difference max-in-interval namespace redis
-                  flood-threshold expire-secs
+                  flood-threshold redis-trace-key-expire-secs
                   pool]
            :or {namespace "clj-rate"}} opts
           flood-cache (ttl-cache interval)
-          expire-secs (or expire-secs (long (Math/ceil (/ interval 1000))))]
+          expire-secs (or redis-trace-key-expire-secs (long (Math/ceil (/ interval 1000))))]
       (reify RateLimiter
         (allow? [this id]
           (:result (permit? this id)))

--- a/src/clj_rate_limiter/core.clj
+++ b/src/clj_rate_limiter/core.clj
@@ -161,11 +161,11 @@
   RateLimiterFactory
   (create [this]
     (let [{:keys [interval min-difference max-in-interval namespace redis
-                  flood-threshold
+                  flood-threshold expire-secs
                   pool]
            :or {namespace "clj-rate"}} opts
           flood-cache (ttl-cache interval)
-          expire-secs (long (Math/ceil (/ interval 1000)))]
+          expire-secs (or expire-secs (long (Math/ceil (/ interval 1000))))]
       (reify RateLimiter
         (allow? [this id]
           (:result (permit? this id)))

--- a/src/clj_rate_limiter/core.clj
+++ b/src/clj_rate_limiter/core.clj
@@ -191,7 +191,6 @@
                                         too-many-in-interval?
                                         (>= total
                                             (* flood-threshold max-in-interval)))
-                               ;; mark flood request
                                (swap! flood-cache assoc id true)
                                true)
                   time-since-last-req (when (and min-difference last-req)


### PR DESCRIPTION
目前发现是 flood 请求时候直接返回 nil 不合理，应该同等返回 result 来着，不然接口约定是被破坏了。